### PR TITLE
Push settings to JSON for use in JS logic.

### DIFF
--- a/finder/static/js/finder.js
+++ b/finder/static/js/finder.js
@@ -1,10 +1,30 @@
+var finder_settings = finder_settings || {};
 var geolocate_supported = true; // until prove false
-
 var geocoder = new google.maps.Geocoder();
-var southwest_limit = new L.LatLng(32.1342, -95.6219); // @todo Replace coordinates.
-var northeast_limit = new L.LatLng(32.6871, -94.9844); // @todo Replace coordinates.
+
+if (typeof finder_settings.EXAMPLE_PLACE_BBOX != 'undefined') {
+    var bounds = finder_settings.EXAMPLE_PLACE_BBOX.split(',');
+    var southwest_limit = new L.LatLng(bounds[0], bounds[1]);
+    var northeast_limit = new L.LatLng(bounds[2], bounds[3]);
+}
+else {
+    var southwest_limit = new L.LatLng(32.1342, -95.6219);
+    var northeast_limit = new L.LatLng(32.6871, -94.9844);
+}
 var bounding_box = new L.LatLngBounds(southwest_limit, northeast_limit);
 var outside = false; // until prove true
+
+if (typeof finder_settings.EXAMPLE_PLACE_LAT_LNG != 'undefined') {
+    var default_latlon = finder_settings.EXAMPLE_PLACE_LAT_LNG.split(',');
+    var default_lat = parseFloat(default_latlon[0]);
+    var default_lon = parseFloat(default_latlon[1]);
+}
+else {
+    var default_lat = 32.349549;
+    var default_lon = -95.301829;
+}
+
+var place = (typeof finder_settings.EXAMPLE_PLACE != 'undefined') ? finder_settings.EXAMPLE_PLACE : 'Example Place';
 
 var map = null;
 
@@ -85,7 +105,7 @@ function geolocate() {
     } else {
         use_default_location();
 
-        $('#resultinfo').html("Your browser does not support automatically determining your location so we're showing you Example Place."); // @todo Replace "Example Place"
+        $('#resultinfo').html("Your browser does not support determining your location, so we're showing" + place + ".");
 
         geolocate_supported = false;
     }
@@ -353,7 +373,7 @@ function use_current_location() {
 }
 
 function use_default_location() {
-    process_location(32.349549, -95.301829); // @todo Replace coordinates.
+    process_location(default_lat, default_lon);
 }
 
 function toggle_alt_addresses() {

--- a/finder/templates/index.html
+++ b/finder/templates/index.html
@@ -45,6 +45,12 @@
 <script src="//maps.google.com/maps/api/js?sensor=true"></script>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js"></script>
 
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+var finder_settings = {{ json_settings|safe }};
+//--><!]]>
+</script>
+
 {% compress js %}
 <script src="{{ STATIC_URL }}leaflet/leaflet.js"></script>
 <script src="{{ STATIC_URL }}js/store.js"></script>

--- a/finder/views.py
+++ b/finder/views.py
@@ -1,3 +1,4 @@
+import json
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.conf import settings
@@ -8,6 +9,17 @@ def settings_processor(request):
 
 def index(request):
     context = RequestContext(request)
+    
+    # Serialize JSON settings to context
+    json_settings = {
+      'EXAMPLE_SCOPE': settings.EXAMPLE_SCOPE,
+      'EXAMPLE_PLACE': settings.EXAMPLE_PLACE,
+      'EXAMPLE_PLACE_LAT_LNG': settings.EXAMPLE_PLACE_LAT_LNG,
+      'EXAMPLE_UNIT': settings.EXAMPLE_UNIT,
+      'EXAMPLE_UNIT_CODE': settings.EXAMPLE_UNIT_CODE,
+      'EXAMPLE_PLACE_BBOX': settings.EXAMPLE_PLACE_BBOX
+    }
+    json_settings = json.dumps(json_settings)
 
     try:
         address = request.REQUEST.get('address')
@@ -15,4 +27,4 @@ def index(request):
     except KeyError:
         pass
 
-    return render_to_response('index.html', context)
+    return render_to_response('index.html', { 'json_settings': json_settings }, context)


### PR DESCRIPTION
This pull request adds a bit of logic to push certain setting values to JSON and into the main template to be used in JS logic.  I assume that these settings will not change, so there is no need to use an AJAX request, so embedding them directly in the template is most efficient.

Please keep in mind that I am very new to Django (and Python) so there could be a better way to do this.

Thanks and great work with the blank boundary service.
